### PR TITLE
T 2270/ucsfcle 405/add tool externaltaskmonitor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ["8.2", "8.3"]
-        moodle-branch: ["MOODLE_404_STABLE"]
+        moodle-branch: ["MOODLE_405_STABLE"]
         database: [pgsql, mariadb]
 
     steps:

--- a/tests/monitor_test.php
+++ b/tests/monitor_test.php
@@ -52,6 +52,7 @@ final class monitor_test extends externallib_advanced_testcase {
      * {@inheritDoc}
      */
     protected function setUp(): void {
+        parent::setUp();
         $this->resetAfterTest();
     }
 

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version = 2025041100;        // The current plugin version (Date: YYYYMMDDXX).
-$plugin->requires = 2024100100;        // Requires this Moodle version.
+$plugin->version = 2025041400;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->requires = 2024100700;        // Requires this Moodle version.
 $plugin->component = 'tool_externaltaskmonitor';      // Full name of the plugin (used for diagnostics).
 $plugin->supported = [405, 405];

--- a/version.php
+++ b/version.php
@@ -24,6 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version = 2024091900;        // The current plugin version (Date: YYYYMMDDXX).
-$plugin->requires = 2024041600;        // Requires this Moodle version.
+$plugin->version = 2025041100;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->requires = 2024100100;        // Requires this Moodle version.
 $plugin->component = 'tool_externaltaskmonitor';      // Full name of the plugin (used for diagnostics).
+$plugin->supported = [405, 405];


### PR DESCRIPTION
Moodle4.5 Update. 

Added code to explicitly call the setup() method on the parent class of our api test case. We're getting dinged for not doing so by the codesniffer in a Moodle 4.5 context, see moodlehq/moodle-cs issue 106 for details.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209228013400278
  - https://app.asana.com/0/0/1209227975135270